### PR TITLE
Version bump.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: analyzer_cli
-version: 0.1.0
+version: 1.0.0
 description: Command line interface for the Dart Analyzer.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/analyzer_cli

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: analyzer_cli
-version: 0.0.1
+version: 0.1.0
 description: Command line interface for the Dart Analyzer.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/analyzer_cli


### PR DESCRIPTION
@stereotype441 
@bwilkerson 

Since this is functionality equivalent to the hosted client code that it will replace my reasoning is that `1.0.0` is a sensible version.  In conversation @stereotype441 was convinced too...  Of course feel free to object!
