### PR TITLE
Basic lint support.

### DIFF
--- a/lib/src/analyzer_impl.dart
+++ b/lib/src/analyzer_impl.dart
@@ -24,6 +24,7 @@ import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/generated/source_io.dart';
 import 'package:analyzer/src/generated/utilities_general.dart';
 import 'package:analyzer_cli/src/error_formatter.dart';
+import 'package:analyzer_cli/src/lint.dart';
 import 'package:analyzer_cli/src/options.dart';
 
 DirectoryBasedDartSdk sdk;
@@ -206,6 +207,7 @@ class AnalyzerImpl {
         _analyzeFunctionBodiesPredicate;
     contextOptions.generateImplicitErrors = options.showPackageWarnings;
     contextOptions.generateSdkErrors = options.showSdkWarnings;
+    contextOptions.lint = options.lints;
     context.analysisOptions = contextOptions;
 
     librarySource = computeLibrarySource();
@@ -244,6 +246,8 @@ class AnalyzerImpl {
     if (sourcePath == null) {
       throw new ArgumentError("sourcePath cannot be null");
     }
+    // register lints
+    registerLints();
     // prepare context
     prepareAnalysisContext();
   }

--- a/lib/src/lint.dart
+++ b/lib/src/lint.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Support for linting.
+/// NOTE: that this library implementation is CERTAIN to change.
+library analyzer_cli.src.lint;
+
+import 'package:analyzer/src/services/lint.dart';
+import 'package:linter/src/linter.dart';
+import 'package:linter/src/rules/camel_case_types.dart';
+import 'package:linter/src/rules/constant_identifier_names.dart';
+import 'package:linter/src/rules/empty_constructor_bodies.dart';
+import 'package:linter/src/rules/library_names.dart';
+import 'package:linter/src/rules/library_prefixes.dart';
+import 'package:linter/src/rules/non_constant_identifier_names.dart';
+import 'package:linter/src/rules/one_member_abstracts.dart';
+import 'package:linter/src/rules/slash_for_doc_comments.dart';
+import 'package:linter/src/rules/super_goes_last.dart';
+import 'package:linter/src/rules/type_init_formals.dart';
+import 'package:linter/src/rules/unnecessary_brace_in_string_interp.dart';
+
+/// Default lint rules. (To be replaced with a plugin contribution.)
+final List<LintRule> _rules = [
+  new CamelCaseTypes(),
+  new ConstantIdentifierNames(),
+  new EmptyConstructorBodies(),
+  new LibraryNames(),
+  new LibraryPrefixes(),
+  new NonConstantIdentifierNames(),
+  new OneMemberAbstracts(),
+  new SlashForDocComments(),
+  new SuperGoesLast(),
+  new TypeInitFormals(),
+  new UnnecessaryBraceInStringInterp()
+];
+
+/// Register default lint rules.
+void registerLints() {
+  LintGenerator.LINTERS.clear();
+  LintGenerator.LINTERS.addAll(_rules);
+}

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -38,6 +38,9 @@ class CommandLineOptions {
   /// Whether to ignore unrecognized flags
   final bool ignoreUnrecognizedFlags;
 
+  /// Whether to report lints
+  final bool lints;
+
   /// Whether to log additional analysis messages and exceptions
   final bool log;
 
@@ -84,6 +87,7 @@ class CommandLineOptions {
         enableStrictCallChecks = args['enable-strict-call-checks'],
         enableTypeChecks = args['enable_type_checks'],
         ignoreUnrecognizedFlags = args['ignore-unrecognized-flags'],
+        lints = args['lints'],
         log = args['log'],
         machineFormat = args['machine'] || args['format'] == 'machine',
         packageRootPath = args['package-root'],
@@ -154,6 +158,8 @@ class CommandLineOptions {
           help: 'Print the analyzer version.',
           defaultsTo: false,
           negatable: false)
+      ..addFlag('lints',
+          help: 'Show lint results.', defaultsTo: false, negatable: false)
       ..addFlag('no-hints',
           help: 'Do not show hint results.',
           defaultsTo: false,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ homepage: https://github.com/dart-lang/analyzer_cli
 dependencies:
   analyzer: '>=0.24.0 <0.26.0'
   args: '>=0.13.0 <0.14.0'
+  linter: '>=0.0.2+1 <0.1.0'
 environment:
   sdk: '>=1.0.0 <2.0.0'
 dev_dependencies:

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -74,13 +74,13 @@ main() {
 
     test('no-hints', () {
       CommandLineOptions options = CommandLineOptions
-      .parse(['--dart-sdk', '.', '--no-hints', 'foo.dart']);
+          .parse(['--dart-sdk', '.', '--no-hints', 'foo.dart']);
       expect(options.disableHints, isTrue);
     });
 
     test('lints', () {
-      CommandLineOptions options = CommandLineOptions
-      .parse(['--dart-sdk', '.', '--lints', 'foo.dart']);
+      CommandLineOptions options =
+          CommandLineOptions.parse(['--dart-sdk', '.', '--lints', 'foo.dart']);
       expect(options.lints, isTrue);
     });
 

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -16,6 +16,7 @@ main() {
       expect(options, isNotNull);
       expect(options.dartSdkPath, isNotNull);
       expect(options.disableHints, isFalse);
+      expect(options.lints, isFalse);
       expect(options.displayVersion, isFalse);
       expect(options.enableStrictCallChecks, isFalse);
       expect(options.enableTypeChecks, isFalse);
@@ -73,8 +74,14 @@ main() {
 
     test('no-hints', () {
       CommandLineOptions options = CommandLineOptions
-          .parse(['--dart-sdk', '.', '--no-hints', 'foo.dart']);
+      .parse(['--dart-sdk', '.', '--no-hints', 'foo.dart']);
       expect(options.disableHints, isTrue);
+    });
+
+    test('lints', () {
+      CommandLineOptions options = CommandLineOptions
+      .parse(['--dart-sdk', '.', '--lints', 'foo.dart']);
+      expect(options.lints, isTrue);
     });
 
     test('package root', () {


### PR DESCRIPTION
Adds a command line flag that enables a default rule set.  

Down the road much of how this is done will be moved to a proper plugin and the documentation specifies as much (and these are all implementation classes beside).

I chose `--lints` but I think `--lint` would work equally well.  Thoughts?

@bwilkerson  
