### PR TITLE
Basic --packages option handling.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: dart
+dart: dev
 script: ./tool/travis.sh
 sudo: false

--- a/lib/src/analyzer_impl.dart
+++ b/lib/src/analyzer_impl.dart
@@ -7,11 +7,6 @@ library analyzer_cli.src.analyzer_impl;
 import 'dart:collection';
 import 'dart:io';
 
-import 'package:analyzer/file_system/file_system.dart' show Folder;
-import 'package:analyzer/file_system/physical_file_system.dart';
-import 'package:analyzer/source/package_map_provider.dart';
-import 'package:analyzer/source/package_map_resolver.dart';
-import 'package:analyzer/source/pub_package_map_provider.dart';
 import 'package:analyzer/src/generated/element.dart';
 import 'package:analyzer/src/generated/engine.dart';
 import 'package:analyzer/src/generated/error.dart';
@@ -121,30 +116,6 @@ class AnalyzerImpl {
   ErrorSeverity analyzeSync({int printMode: 1}) {
     setupForAnalysis();
     return _analyzeSync(printMode);
-  }
-
-  /// Create and return the source factory to be used by the analysis context.
-  SourceFactory createSourceFactory() {
-    List<UriResolver> resolvers = [
-      new CustomUriResolver(options.customUrlMappings),
-      new DartUriResolver(sdk)
-    ];
-    if (options.packageRootPath != null) {
-      JavaFile packageDirectory = new JavaFile(options.packageRootPath);
-      resolvers.add(new PackageUriResolver([packageDirectory]));
-    } else {
-      PubPackageMapProvider pubPackageMapProvider =
-          new PubPackageMapProvider(PhysicalResourceProvider.INSTANCE, sdk);
-      PackageMapInfo packageMapInfo = pubPackageMapProvider.computePackageMap(
-          PhysicalResourceProvider.INSTANCE.getResource('.'));
-      Map<String, List<Folder>> packageMap = packageMapInfo.packageMap;
-      if (packageMap != null) {
-        resolvers.add(new PackageMapUriResolver(
-            PhysicalResourceProvider.INSTANCE, packageMap));
-      }
-    }
-    resolvers.add(new FileUriResolver());
-    return new SourceFactory(resolvers);
   }
 
   /// Fills [errorInfos] using [sources].

--- a/lib/src/driver.dart
+++ b/lib/src/driver.dart
@@ -25,7 +25,7 @@ import 'package:analyzer/src/generated/source_io.dart';
 import 'package:analyzer_cli/src/analyzer_impl.dart';
 import 'package:analyzer_cli/src/options.dart';
 import 'package:linter/src/plugin/linter_plugin.dart';
-//import 'package:package_config/packages_file.dart' as pkgfile show parse;
+import 'package:package_config/packages_file.dart' as pkgfile show parse;
 import 'package:path/path.dart' as path;
 import 'package:plugin/manager.dart';
 import 'package:plugin/plugin.dart';
@@ -233,12 +233,20 @@ class Driver {
     ];
 
     if (options.packageConfigPath != null) {
-      // TODO(pquitslund): plug into new resolver once implemented
-      // https://github.com/dart-lang/sdk/issues/23615
-      // Uri fileUri = new Uri.file(options.packageConfigPath);
-      // File configFile = new File.fromUri(fileUri);
-      // List<int> bytes = configFile.readAsBytesSync();
-      // Map<String, Uri> map = pkgfile.parse(bytes, fileUri);
+      String packageConfigPath = options.packageConfigPath;
+      Uri fileUri = new Uri.file(packageConfigPath);
+      try {
+        File configFile = new File.fromUri(fileUri);
+        List<int> bytes = configFile.readAsBytesSync();
+        Map<String, Uri> map = pkgfile.parse(bytes, fileUri);
+        // TODO(pquitslund): plug into new resolver once implemented
+        // https://github.com/dart-lang/sdk/issues/23615
+      } catch (e) {
+        printAndFail(
+            'Unable to read package config data from $packageConfigPath: $e');
+      }
+      printAndFail(
+          'Package config files are not supported yet. For status see: https://github.com/dart-lang/sdk/issues/23373');
     } else if (options.packageRootPath != null) {
       JavaFile packageDirectory = new JavaFile(options.packageRootPath);
       resolvers.add(new PackageUriResolver([packageDirectory]));

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -11,6 +11,12 @@ import 'package:cli_util/cli_util.dart' show getSdkDir;
 
 const _binaryName = 'dartanalyzer';
 
+/// Print the given message and exit with the given [exitCode]
+void printAndFail(String message, {int exitCode: 15}) {
+  print(message);
+  exit(exitCode);
+}
+
 /// Analyzer commandline configuration options.
 class CommandLineOptions {
   /// The path to the dart SDK
@@ -290,11 +296,6 @@ class CommandLineOptions {
       _showUsage(parser);
       exit(15);
     }
-  }
-
-  static void _printAndFail(String msg) {
-    print(msg);
-    exit(15);
   }
 
   static _showUsage(parser) {

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -122,11 +122,11 @@ class CommandLineOptions {
 
       // check that SDK is specified
       if (sdkPath == null) {
-        _printAndFail('Usage: $_binaryName: no Dart SDK found.');
+        printAndFail('Usage: $_binaryName: no Dart SDK found.');
       }
       // check that SDK is existing directory
       if (!(new Directory(sdkPath)).existsSync()) {
-        _printAndFail('Usage: $_binaryName: invalid Dart SDK path: $sdkPath');
+        printAndFail('Usage: $_binaryName: invalid Dart SDK path: $sdkPath');
       }
     }
 
@@ -134,7 +134,7 @@ class CommandLineOptions {
     {
       if (options.packageRootPath != null &&
           options.packageConfigPath != null) {
-        _printAndFail("Cannot specify both '--package-root' and '--packages.");
+        printAndFail("Cannot specify both '--package-root' and '--packages.");
       }
     }
 

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -51,6 +51,9 @@ class CommandLineOptions {
   /// The path to the package root
   final String packageRootPath;
 
+  /// The path to a `.packages` configuration file
+  final String packageConfigPath;
+
   /// Batch mode (for unit testing)
   final bool shouldBatch;
 
@@ -85,6 +88,7 @@ class CommandLineOptions {
         lints = args['lints'],
         log = args['log'],
         machineFormat = args['machine'] || args['format'] == 'machine',
+        packageConfigPath = args['packages'],
         packageRootPath = args['package-root'],
         shouldBatch = args['batch'],
         showPackageWarnings = args['show-package-warnings'] ||
@@ -104,7 +108,7 @@ class CommandLineOptions {
       if (options.dartSdkPath == null) {
         Directory sdkDir = getSdkDir(args);
         if (sdkDir != null) {
-          options.dartSdkPath  = sdkDir.path;
+          options.dartSdkPath = sdkDir.path;
         }
       }
 
@@ -112,15 +116,22 @@ class CommandLineOptions {
 
       // check that SDK is specified
       if (sdkPath == null) {
-        print('Usage: $_binaryName: no Dart SDK found.');
-        exit(15);
+        _printAndFail('Usage: $_binaryName: no Dart SDK found.');
       }
       // check that SDK is existing directory
       if (!(new Directory(sdkPath)).existsSync()) {
-        print('Usage: $_binaryName: invalid Dart SDK path: $sdkPath');
-        exit(15);
+        _printAndFail('Usage: $_binaryName: invalid Dart SDK path: $sdkPath');
       }
     }
+
+    // check package config
+    {
+      if (options.packageRootPath != null &&
+          options.packageConfigPath != null) {
+        _printAndFail("Cannot specify both '--package-root' and '--packages.");
+      }
+    }
+
     // OK
     return options;
   }
@@ -147,9 +158,11 @@ class CommandLineOptions {
           defaultsTo: false,
           negatable: false)
       ..addOption('dart-sdk', help: 'The path to the Dart SDK.')
+      ..addOption('packages',
+          help: 'Path to the package resolution configuration file, which supplies a mapping of package names to paths.  This option cannot be used with --package-root.')
       ..addOption('package-root',
           abbr: 'p',
-          help: 'The path to the package root. The flag package-root is deprecated. Remove to use package information computed by pub.')
+          help: 'Path to a package root directory (deprecated). This option cannot be used with --packages.')
       ..addOption('format',
           help: 'Specifies the format in which errors are displayed.')
       ..addFlag('machine',
@@ -277,6 +290,11 @@ class CommandLineOptions {
       _showUsage(parser);
       exit(15);
     }
+  }
+
+  static void _printAndFail(String msg) {
+    print(msg);
+    exit(15);
   }
 
   static _showUsage(parser) {
@@ -408,7 +426,7 @@ class CommandLineParser {
     }
   }
 
-  _getNextFlagIndex(args, i) {
+  int _getNextFlagIndex(args, i) {
     for (; i < args.length; ++i) {
       if (args[i].startsWith('--')) {
         return i;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ dependencies:
   args: ^0.13.0
   cli_util: ^0.0.1
   linter: ^0.1.0
+  package_config: ^0.0.3+1
   plugin: ^0.1.0
 environment:
   sdk: '>=1.8.0 <2.0.0'


### PR DESCRIPTION
Baby steps.

We can finish wiring up the `SourceFactory` once we have an appropriate resolver implemented (https://github.com/dart-lang/sdk/issues/23615).
