### PR TITLE
Integrate dev_compiler strong typechecking into analyzer_cli

### DIFF
--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -87,6 +87,12 @@ class CommandLineOptions {
   /// source is located.
   final Map<String, String> customUrlMappings;
 
+  /// Whether to use package:dev_compiler for strong static checking.
+  final bool strongMode;
+
+  /// Whether to emit hints from [strongMode] analysis.
+  final bool strongHints;
+
   /// Initialize options from the given parsed [args].
   CommandLineOptions._fromArgs(ArgResults args,
       Map<String, String> definedVariables,
@@ -111,7 +117,9 @@ class CommandLineOptions {
         showSdkWarnings = args['show-sdk-warnings'] || args['warnings'],
         sourceFiles = args.rest,
         warningsAreFatal = args['fatal-warnings'],
-        this.customUrlMappings = customUrlMappings;
+        this.customUrlMappings = customUrlMappings,
+        strongMode = args['strong'],
+        strongHints = args['strong-hints'];
 
   /// Parse [args] into [CommandLineOptions] describing the specified
   /// analyzer options. In case of a format error, calls [printAndFail], which
@@ -263,7 +271,13 @@ class CommandLineOptions {
           help: 'Check types in constant evaluation.',
           defaultsTo: false,
           negatable: false,
+          hide: true)
+      // TODO(jmesserly): link to a spec+explainer for these checks.
+      ..addFlag('strong', help: 'Enable strong static checks.', hide: true)
+      ..addFlag('strong-hints',
+          help: 'Enable hints about dynamic operations.',
           hide: true);
+
 
     try {
       // TODO(scheglov) https://code.google.com/p/dart/issues/detail?id=11061

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   analyzer: ^0.25.1-alpha.2
   args: ^0.13.0
   cli_util: ^0.0.1
+  dev_compiler: ^0.1.1
   linter: ^0.1.0
   package_config: ^0.0.3+1
   plugin: ^0.1.0

--- a/test/all.dart
+++ b/test/all.dart
@@ -8,6 +8,7 @@ import 'driver_test.dart' as driver;
 import 'error_test.dart' as error;
 import 'options_test.dart' as options;
 import 'reporter_test.dart' as reporter;
+import 'strong_mode_test.dart' as strong_mode;
 
 main() {
   // Tidy up output.
@@ -18,4 +19,5 @@ main() {
   error.main();
   options.main();
   reporter.main();
+  strong_mode.main();
 }

--- a/test/data/strong_example.dart
+++ b/test/data/strong_example.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// This produces an error with --strong enabled, but not otherwise.
+class MyIterable extends Iterable<String> {
+  // Error: invalid override
+  Iterator<Object> get iterator => [1, 2, 3].iterator;
+}
+
+main() {
+  var i = new MyIterable().iterator..moveNext();
+  print(i.current);
+
+  // Error: type check failed
+  List<String> list = <dynamic>[1, 2, 3];
+  print(list);
+}

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -34,6 +34,7 @@ main() {
         expect(options.warningsAreFatal, isFalse);
         expect(options.customUrlMappings, isNotNull);
         expect(options.customUrlMappings.isEmpty, isTrue);
+        expect(options.strongMode, isFalse);
       });
 
       test('batch', () {
@@ -164,6 +165,13 @@ main() {
             parser.parse(['--optionA=1', '--optionB=2', '--flagA'], {});
         expect(argResults['optionA'], '1');
         expect(argResults['flagA'], isTrue);
+      });
+
+      test('strong mode', () {
+        CommandLineOptions options = CommandLineOptions
+            .parse(['--strong', '--strong-hints', 'foo.dart']);
+        expect(options.strongMode, isTrue);
+        expect(options.strongHints, isTrue);
       });
 
       test("can't specify package and package-root", () {

--- a/test/strong_mode_test.dart
+++ b/test/strong_mode_test.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library analyzer_cli.test.strong_mode;
+
+import 'dart:io';
+import 'dart:mirrors';
+import 'package:analyzer_cli/src/driver.dart' show Driver, errorSink, outSink;
+import 'package:path/path.dart' as path;
+import 'package:unittest/unittest.dart';
+
+/// End-to-end test for --strong checking.
+///
+/// Most StrongChecker tests are in dev_compiler/test/checker/*_test.dart, but
+/// this verifies the option is working and producing extra errors as expected.
+///
+/// Generally we don't want a lot of cases here as it requires spinning up a
+/// full analysis context.
+void main() {
+  groupSep = ' | ';
+
+  group('--strong', () {
+    StringSink savedOutSink, savedErrorSink;
+    int savedExitCode;
+    setUp(() {
+      savedOutSink = outSink;
+      savedErrorSink = errorSink;
+      savedExitCode = exitCode;
+      outSink = new StringBuffer();
+      errorSink = new StringBuffer();
+    });
+    tearDown(() {
+      outSink = savedOutSink;
+      errorSink = savedErrorSink;
+      exitCode = savedExitCode;
+    });
+
+    test('produces stricter errors', () async {
+      var testPath = path.join(testDirectory, 'data/strong_example.dart');
+      new Driver().start(['--strong', testPath]);
+
+      expect(exitCode, 3);
+      var stdout = outSink.toString();
+      expect(stdout, contains('[error] Invalid override'));
+      expect(stdout, contains('[error] Type check failed'));
+      expect(stdout, contains('2 errors found.'));
+      expect(errorSink.toString(), '');
+    });
+  });
+}
+
+/// Gets the test directory in a way that works with
+/// package:test and package:unittest.
+/// See <https://github.com/dart-lang/test/issues/110> for more info.
+final String testDirectory =
+    path.dirname((reflectClass(_TestUtils).owner as LibraryMirror).uri.path);
+
+class _TestUtils {}


### PR DESCRIPTION
Adds an experimental strong checking mode, with associated test.

The flag is hidden by default, which seems to be the convention of existing experimental options. Also adds --verbose-help to show these experiments (otherwise it'd be hard to know what the strong mode options are).

Right now the StrongChecker is a separate pass (except inference, which has to happen sooner). I think we may want to restructure it to compute its errors as part of normal resolution, which would let us revert changes to analyzer_impl.dart, in favor of setting things up when we create the AnalysisContext. But that needs a fix to https://github.com/dart-lang/dev_compiler/issues/6.

Tried to keep the changes as small as possible. Mostly around options. The dev_compiler side of this was: https://github.com/dart-lang/dev_compiler/commit/0ff64c1c9805e8fe6406e2acb05e34891d2f9f83 ... ironically that too was mostly changing options :)

As analyzer_cli is pulled into Dart SDK repo via DEPS, here is the corresponding change that adds dev_compiler and its dependencies: https://codereview.chromium.org/1167673004/
