### PR TITLE
Deprecate "--enable-null-aware-operators".

### DIFF
--- a/lib/src/driver.dart
+++ b/lib/src/driver.dart
@@ -178,10 +178,6 @@ class Driver {
     if (options.disableHints != _previousOptions.disableHints) {
       return false;
     }
-    if (options.enableNullAwareOperators !=
-        _previousOptions.enableNullAwareOperators) {
-      return false;
-    }
     if (options.enableStrictCallChecks !=
         _previousOptions.enableStrictCallChecks) {
       return false;
@@ -361,7 +357,6 @@ class Driver {
     AnalysisOptionsImpl contextOptions = new AnalysisOptionsImpl();
     contextOptions.cacheSize = _maxCacheSize;
     contextOptions.hint = !options.disableHints;
-    contextOptions.enableNullAwareOperators = options.enableNullAwareOperators;
     contextOptions.enableStrictCallChecks = options.enableStrictCallChecks;
     contextOptions.analyzeFunctionBodiesPredicate = dietParsingPolicy;
     contextOptions.generateImplicitErrors = options.showPackageWarnings;

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -153,7 +153,12 @@ class CommandLineOptions {
       }
     }
 
-    // OK
+    // OK.  Report deprecated options.
+    if (options.enableNullAwareOperators) {
+      print(
+          "Info: Option '--enable-null-aware-operators' is no longer needed. Null aware operators are supported by default.");
+    }
+
     return options;
   }
 
@@ -271,9 +276,7 @@ class CommandLineOptions {
       // TODO(jmesserly): link to a spec+explainer for these checks.
       ..addFlag('strong', help: 'Enable strong static checks.', hide: true)
       ..addFlag('strong-hints',
-          help: 'Enable hints about dynamic operations.',
-          hide: true);
-
+          help: 'Enable hints about dynamic operations.', hide: true);
 
     try {
       // TODO(scheglov) https://code.google.com/p/dart/issues/detail?id=11061


### PR DESCRIPTION
As of analyzer 0.25.2, this option is no longer needed; null-aware
operators are always enabled.

@pq
