### PR TITLE
Ensure SdkExt resolvers are properly registered.

### DIFF
--- a/lib/src/driver.dart
+++ b/lib/src/driver.dart
@@ -392,8 +392,7 @@ class Driver {
   /// Return discovered packagespec, or `null` if none is found.
   Packages _discoverPackagespec(Uri root) {
     try {
-      Packages packages =
-          pkgDiscovery.findPackagesFromFile(new Uri.directory(root.path));
+      Packages packages = pkgDiscovery.findPackagesFromFile(root);
       if (packages != Packages.noPackages) {
         return packages;
       }

--- a/lib/src/driver.dart
+++ b/lib/src/driver.dart
@@ -54,7 +54,6 @@ const int _maxCacheSize = 512;
 typedef ErrorSeverity _BatchRunnerHandler(List<String> args);
 
 class Driver {
-
   /// The plugins that are defined outside the `analyzer_cli` package.
   List<Plugin> _userDefinedPlugins = <Plugin>[];
 
@@ -286,7 +285,6 @@ class Driver {
       if (packages != null) {
         packageMap = _getPackageMap(packages);
       } else {
-
         // Fall back to pub list-dir.
 
         PubPackageMapProvider pubPackageMapProvider =
@@ -413,8 +411,10 @@ class Driver {
 
     Map<String, List<fileSystem.Folder>> folderMap =
         new Map<String, List<fileSystem.Folder>>();
-    packages.asMap().forEach((String path, Uri uri) {
-      folderMap[path] = [PhysicalResourceProvider.INSTANCE.getFolder(uri.path)];
+    packages.asMap().forEach((String packagePath, Uri uri) {
+      folderMap[packagePath] = [
+        PhysicalResourceProvider.INSTANCE.getFolder(path.fromUri(uri))
+      ];
     });
     return folderMap;
   }
@@ -564,8 +564,9 @@ class _PackageRootPackageMapBuilder {
     for (var package in packages) {
       var packageName = path.basename(package.path);
       var realPath = package.resolveSymbolicLinksSync();
-      result[packageName] =
-          [PhysicalResourceProvider.INSTANCE.getFolder(realPath)];
+      result[packageName] = [
+        PhysicalResourceProvider.INSTANCE.getFolder(realPath)
+      ];
     }
     return result;
   }


### PR DESCRIPTION
@johnmccutchan @bwilkerson @stereotype441 PTAL.

This could be tightened up (and surely will be once `ContextManager` is doing more of this heavy lifting) but I wanted to make sure I preserved the existing behavior.  In particular, I took pains to ensure that resolvers are added in the same order.  This _may_ be unnecessary but seems safest.  Needless to say, this will get cleaned up majorly down the road.  In the meantime, I hope it gets `SdkExt` support in a world of `.packages` on its feet.  Let me know if you think otherwise!
