### PR TITLE
Don't create a PackageMapUriResolver if "pub list-package-dirs" failed.

### DIFF
--- a/lib/src/driver.dart
+++ b/lib/src/driver.dart
@@ -285,7 +285,7 @@ class Driver {
       if (packages != null) {
         packageMap = _getPackageMap(packages);
       } else {
-        // Fall back to pub list-dir.
+        // Fall back to pub list-package-dirs.
 
         PubPackageMapProvider pubPackageMapProvider =
             new PubPackageMapProvider(PhysicalResourceProvider.INSTANCE, sdk);
@@ -293,8 +293,13 @@ class Driver {
             pubPackageMapProvider.computePackageMap(cwd);
         packageMap = packageMapInfo.packageMap;
 
-        packageUriResolver = new PackageMapUriResolver(
-            PhysicalResourceProvider.INSTANCE, packageMap);
+        // Only create a packageUriResolver if pub list-package-dirs succeeded.
+        // If it failed, that's not a problem; it simply means we have no way
+        // to resolve packages.
+        if (packageMapInfo.packageMap != null) {
+          packageUriResolver = new PackageMapUriResolver(
+              PhysicalResourceProvider.INSTANCE, packageMap);
+        }
       }
     }
 


### PR DESCRIPTION
This addresses the use case where the code being analyzed has no
package resolution mechanism at all (no ".packages" file, no
"packages" folder, and no pubspec).  Previously, this use case would
lead to an unhandled exception because we would try to pass null to
the PackageMapUriResolver constructor.

@bwilkerson @pq
