### PR TITLE
Remove bogus "@TestOn" annotation in mocks.dart

### DIFF
--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@TestOn("vm")
-
 library analyzer_cli.test.mocks;
 
 import 'package:analyzer/analyzer.dart';


### PR DESCRIPTION
This file doesn't define any tests, so there's no need for the
annotation.  Fixes a static analysis error, since mocks.dart doesn't
import the necessary package to even resolve the symbol.

TBR @bwilkerson 
