### PR TITLE
Add support for DEP 34, under the flag "--supermixin"

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -1,3 +1,4 @@
 analyzer:
   exclude:
     - test/data/no_packages_file/sdk_ext_user.dart
+    - test/data/super_mixin_example.dart

--- a/lib/src/driver.dart
+++ b/lib/src/driver.dart
@@ -194,6 +194,9 @@ class Driver {
     if (options.strongMode != _previousOptions.strongMode) {
       return false;
     }
+    if (options.enableSuperMixins != _previousOptions.enableSuperMixins) {
+      return false;
+    }
     return true;
   }
 
@@ -386,6 +389,7 @@ class Driver {
     contextOptions.cacheSize = _maxCacheSize;
     contextOptions.hint = !options.disableHints;
     contextOptions.enableStrictCallChecks = options.enableStrictCallChecks;
+    contextOptions.enableSuperMixins = options.enableSuperMixins;
     contextOptions.analyzeFunctionBodiesPredicate = dietParsingPolicy;
     contextOptions.generateImplicitErrors = options.showPackageWarnings;
     contextOptions.generateSdkErrors = options.showSdkWarnings;

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -42,6 +42,9 @@ class CommandLineOptions {
   /// "call" methods (fixes dartbug.com/21938).
   final bool enableStrictCallChecks;
 
+  /// Whether to relax restrictions on mixins (DEP 34).
+  final bool enableSuperMixins;
+
   /// Whether to treat type mismatches found during constant evaluation as
   /// errors.
   final bool enableTypeChecks;
@@ -100,6 +103,7 @@ class CommandLineOptions {
         displayVersion = args['version'],
         enableNullAwareOperators = args['enable-null-aware-operators'],
         enableStrictCallChecks = args['enable-strict-call-checks'],
+        enableSuperMixins = args['supermixin'],
         enableTypeChecks = args['enable_type_checks'],
         ignoreUnrecognizedFlags = args['ignore-unrecognized-flags'],
         lints = args['lints'],
@@ -260,6 +264,11 @@ class CommandLineOptions {
           hide: true)
       ..addFlag('enable-strict-call-checks',
           help: 'Fix issue 21938.',
+          defaultsTo: false,
+          negatable: false,
+          hide: true)
+      ..addFlag('supermixin',
+          help: 'Relax restrictions on mixins (DEP 34).',
           defaultsTo: false,
           negatable: false,
           hide: true)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: analyzer_cli
 version: 1.1.0
-description: Command line interface for the Dart Analyzer.
 author: Dart Team <misc@dartlang.org>
+description: Command line interface for the Dart Analyzer.
 homepage: https://github.com/dart-lang/analyzer_cli
 environment:
   sdk: '>=1.8.0 <2.0.0'
 dependencies:
-  analyzer: ^0.25.3-alpha.1
+  analyzer: ^0.26.0
   args: ^0.13.0
   cli_util: ^0.0.1
   dev_compiler: ^0.1.1

--- a/test/all.dart
+++ b/test/all.dart
@@ -8,6 +8,7 @@ import 'options_test.dart' as options;
 import 'reporter_test.dart' as reporter;
 import 'sdk_ext_test.dart' as sdk_ext;
 import 'strong_mode_test.dart' as strong_mode;
+import 'super_mixin_test.dart' as super_mixin;
 
 main() {
   driver.main();
@@ -16,4 +17,5 @@ main() {
   reporter.main();
   sdk_ext.main();
   strong_mode.main();
+  super_mixin.main();
 }

--- a/test/data/super_mixin_example.dart
+++ b/test/data/super_mixin_example.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// This produces errors normally, but --supermixin disables them.
+class Test extends Object with C {
+  void foo() {}
+}
+
+abstract class B {
+  void foo();
+}
+
+abstract class C extends B {
+  void bar() {
+    super.foo();
+  }
+}

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -22,6 +22,7 @@ main() {
         expect(options.lints, isFalse);
         expect(options.displayVersion, isFalse);
         expect(options.enableStrictCallChecks, isFalse);
+        expect(options.enableSuperMixins, isFalse);
         expect(options.enableTypeChecks, isFalse);
         expect(options.ignoreUnrecognizedFlags, isFalse);
         expect(options.log, isFalse);
@@ -54,6 +55,12 @@ main() {
         CommandLineOptions options = CommandLineOptions.parse(
             ['--dart-sdk', '.', '--enable-strict-call-checks', 'foo.dart']);
         expect(options.enableStrictCallChecks, isTrue);
+      });
+
+      test('enable super mixins', () {
+        CommandLineOptions options = CommandLineOptions
+            .parse(['--dart-sdk', '.', '--supermixin', 'foo.dart']);
+        expect(options.enableSuperMixins, isTrue);
       });
 
       test('enable type checks', () {

--- a/test/super_mixin_test.dart
+++ b/test/super_mixin_test.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn("vm")
+library analyzer_cli.test.super_mixin;
+
+import 'dart:io';
+
+import 'package:analyzer_cli/src/driver.dart' show Driver, errorSink, outSink;
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+import 'utils.dart';
+
+/// End-to-end test for --strong checking.
+///
+/// Most StrongChecker tests are in dev_compiler/test/checker/*_test.dart, but
+/// this verifies the option is working and producing extra errors as expected.
+///
+/// Generally we don't want a lot of cases here as it requires spinning up a
+/// full analysis context.
+void main() {
+  group('--supermixins', () {
+    StringSink savedOutSink, savedErrorSink;
+    int savedExitCode;
+    setUp(() {
+      savedOutSink = outSink;
+      savedErrorSink = errorSink;
+      savedExitCode = exitCode;
+      outSink = new StringBuffer();
+      errorSink = new StringBuffer();
+    });
+    tearDown(() {
+      outSink = savedOutSink;
+      errorSink = savedErrorSink;
+      exitCode = savedExitCode;
+    });
+
+    test('produces errors when option absent', () async {
+      var testPath = path.join(testDirectory, 'data/super_mixin_example.dart');
+      new Driver().start([testPath]);
+
+      expect(exitCode, 3);
+      var stdout = outSink.toString();
+      expect(
+          stdout,
+          contains(
+              "[error] The class 'C' cannot be used as a mixin because it extends a class other than Object"));
+      expect(
+          stdout,
+          contains(
+              "[error] The class 'C' cannot be used as a mixin because it references 'super'"));
+      expect(stdout, contains('2 errors found.'));
+      expect(errorSink.toString(), '');
+    });
+
+    test('produces no errors when option present', () async {
+      var testPath = path.join(testDirectory, 'data/super_mixin_example.dart');
+      new Driver().start(['--supermixin', testPath]);
+
+      expect(exitCode, 0);
+      var stdout = outSink.toString();
+      expect(stdout, contains('No issues found'));
+    });
+  });
+}


### PR DESCRIPTION
The flag name was chosen to match the flag that already exists in the VM and the shared tests in the SDK.

@pq
