### PR TITLE
Change analyzer dependency to 0.28.1+8.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/dart-lang/analyzer_cli
 environment:
   sdk: '>=1.12.0 <2.0.0'
 dependencies:
-  analyzer: ^0.26.0+6
+  analyzer: ^0.26.1+8
   args: ^0.13.0
   cli_util: ^0.0.1
   dev_compiler: ^0.1.1


### PR DESCRIPTION
This brings in fixes which are required to support lints with the new
task model.
